### PR TITLE
Updated fred_plot calls to include -d 0 so PDF are not opened

### DIFF
--- a/flu-with-behavior/METHODS
+++ b/flu-with-behavior/METHODS
@@ -17,4 +17,4 @@ fred_job -k flu-with-behavior -p main.fred -n 4 -m 2
 fred_plot -o flatten -k simpleflu,flu-with-behavior \
 	  -v INFLUENZA.newExposed,INFLUENZA.newExposed \
 	  -t "Flattening the Curve"  \
-	  -l NoDistancing,Distancing --clean
+	  -l NoDistancing,Distancing -d 0 --clean

--- a/school-closure/METHODS
+++ b/school-closure/METHODS
@@ -126,25 +126,25 @@ fred_plot -o closed -t "Number of Schools Closed" \
 	  -k local,global,no_closure,no_closure,no_closure \
 	  -v SCHOOL.Close,SCHOOL.Close,SCHOOL.SpringBreak,SCHOOL.SummerBreak,SCHOOL.WinterBreak \
 	  -l Local,Global,Spring,Summer,Winter \
-	  --ylabel "Schools" -M --year --leg out --clean --xlabel "Date"
+	  --ylabel "Schools" -M --year --leg out -d 0 --clean --xlabel "Date"
 
 fred_plot -o tot -t "Total Cases" \
 	  -k no_closure,local,global \
 	  -v INF.totE,INF.totE,INF.totE \
 	  -l 'No Closure','Local Incidence','Global Incidence' \
-	  -n -s 100 -M --year --clean --leg bottom --xlabel "Date"
+	  -n -s 100 -M --year -d 0 --clean --leg bottom --xlabel "Date"
 
 fred_plot -o inc -t "New Cases" \
 	  -k no_closure,local,global \
 	  -v INF.newE,INF.newE,INF.newE \
 	  -l 'No Closure','Local Incidence','Global Incidence' \
-	  -n -s 100 -M --year --clean --xlabel "Date"
+	  -n -s 100 -M --year -d 0 --clean --xlabel "Date"
 
 fred_plot -o students -t "Number of Students out of School" \
 	  -k local,global,no_closure \
 	  -v SCHOOL.StudentSchoolClosed,SCHOOL.StudentSchoolClosed,SCHOOL.StudentSchoolClosed \
 	  -l 'Local','Global','No Closure' \
-	  --ylabel "Students" -M --year --clean --xlabel "Date" --legend out
+	  --ylabel "Students" -M --year -d 0 --clean --xlabel "Date" --legend out
 
 
 
@@ -154,25 +154,25 @@ fred_plot -o local_trigs_tot -t "Local Closure Total Infected" \
 	  -k local_trigger_10,local,local_trigger_30 \
 	  -v INF.totE,INF.totE,INF.totE \
 	  -l 'Trigger = 10','Trigger = 20','Trigger = 30' \
-	  -n -s 100 -M --year --clean --leg bottom --xlabel "Date"
+	  -n -s 100 -M --year -d 0 --clean --leg bottom --xlabel "Date"
 
 fred_plot -o global_trigs_tot -t "Global Closure Total Infected" \
 	  -k global_trigger_500,global,global_trigger_1500 \
 	  -v INF.totE,INF.totE,INF.totE \
 	  -l 'Trigger = 500','Trigger = 1000','Trigger = 1500' \
-	  -n -s 100 -M --year --clean --leg bottom --xlabel "Date"
+	  -n -s 100 -M --year -d 0 --clean --leg bottom --xlabel "Date"
 
 fred_plot -o global_days_closed_tot -t "Global Closure Total Infected" \
 	  -k global_closed_14,global,global_closed_56 \
 	  -v INF.totE,INF.totE,INF.totE \
 	  -l 'days_closed = 14','days_closed = 28','days_closed = 56' \
-	  -n -s 100 -M --year --clean --leg bottom --xlabel "Date"
+	  -n -s 100 -M --year -d 0 --clean --leg bottom --xlabel "Date"
 
 fred_plot -o local_days_closed_tot -t "Local Closure Total Infected" \
 	  -k local_closed_14,local,local_closed_56 \
 	  -v INF.totE,INF.totE,INF.totE \
 	  -l 'days_closed = 14','days_closed = 28','days_closed = 56' \
-	  -n -s 100 -M --year --clean --leg bottom --xlabel "Date"
+	  -n -s 100 -M --year -d 0 --clean --leg bottom --xlabel "Date"
 
 
 ################## New Cases
@@ -182,22 +182,22 @@ fred_plot -o local_trigs_new -t "Local Closure New Infected" \
 	  -k local_trigger_10,local,local_trigger_30 \
 	  -v INF.newE,INF.newE,INF.newE \
 	  -l 'Trigger = 10','Trigger = 20','Trigger = 30' \
-	  -n -s 100 -M --year --clean --leg top --xlabel "Date"
+	  -n -s 100 -M --year -d 0 --clean --leg top --xlabel "Date"
 
 fred_plot -o global_trigs_new -t "Global Closure New Infected" \
 	  -k global_trigger_500,global,global_trigger_1500 \
 	  -v INF.newE,INF.newE,INF.newE \
 	  -l 'Trigger = 500','Trigger = 1000','Trigger = 1500' \
-	  -n -s 100 -M --year --clean --leg top --xlabel "Date"
+	  -n -s 100 -M --year -d 0 --clean --leg top --xlabel "Date"
 
 fred_plot -o global_days_closed_new -t "Global Closure New Infected" \
 	  -k global_closed_14,global,global_closed_56 \
 	  -v INF.newE,INF.newE,INF.newE \
 	  -l 'days_closed = 14','days_closed = 28','days_closed = 56' \
-	  -n -s 100 -M --year --clean --leg top --xlabel "Date"
+	  -n -s 100 -M --year -d 0 --clean --leg top --xlabel "Date"
 
 fred_plot -o local_days_closed_new -t "Local Closure New Infected" \
 	  -k local_closed_14,local,local_closed_56 \
 	  -v INF.newE,INF.newE,INF.newE \
 	  -l 'days_closed = 14','days_closed = 28','days_closed = 56' \
-	  -n -s 100 -M --year --clean --leg top --xlabel "Date"
+	  -n -s 100 -M --year -d 0 --clean --leg top --xlabel "Date"

--- a/school-closure/parameters.fred
+++ b/school-closure/parameters.fred
@@ -1,3 +1,4 @@
 parameters {
     school_closure_policy = GLOBAL_CLOSURE
+    days_closed = 56
 }

--- a/simpleflu/METHODS
+++ b/simpleflu/METHODS
@@ -3,9 +3,9 @@ fred_delete -f -k simpleflu
 
 fred_job -k simpleflu -p main.fred -n 4 -m 2
 
-fred_plot -o daily -k simpleflu -v INFLUENZA.newExposed -b -t "Simple Flu Model"  -l "Daily Incidence" --clean
+fred_plot -o daily -k simpleflu -v INFLUENZA.newExposed -b -t "Simple Flu Model"  -l "Daily Incidence" -d 0 --clean
 
-fred_plot -o weekly -k simpleflu -v INFLUENZA.newExposed -b -t "Simple Flu Model" -l "Weekly Incidence" -w --clean
+fred_plot -o weekly -k simpleflu -v INFLUENZA.newExposed -b -t "Simple Flu Model" -l "Weekly Incidence" -d 0 -w --clean
 
 
 

--- a/vaccine/METHODS
+++ b/vaccine/METHODS
@@ -18,8 +18,8 @@ fred_job -k vaccine -p main.fred -n 4 -m 2
 
 fred_plot -o vaccine-inc -k novaccine,vaccine -v INFLUENZA.newExposed,INFLUENZA.newExposed \
 	  -t "Effect of Vaccine"  \
-	  -l NoVaccine,Vaccine --clean -M
+	  -l NoVaccine,Vaccine -d 0 --clean -M
 
 fred_plot -o vaccine-tot -k novaccine,vaccine -v INFLUENZA.totExposed,INFLUENZA.totExposed \
 	  -t "Effect of Vaccine"  \
-	  -l NoVaccine,Vaccine --clean -M
+	  -l NoVaccine,Vaccine -d 0 --clean -M


### PR DESCRIPTION
Modified the tutorials to work better with our FRED Local docker image.  By default fred_plot calls the Mac open command to open the PDF files, which fails in our docker image.

Added "-d 0" (-display no) so that the PDF files are not displayed by default. This removes the error on other platforms.