### PR TITLE
Updated text to use or reference FRED Local to run models

### DIFF
--- a/school-closure/README.rst
+++ b/school-closure/README.rst
@@ -132,16 +132,23 @@ for the local policy.
 Modifying Closure Variables
 ---------------------------
 
-Variables are modified via the ``METHODS`` script which overwrites
-various combinations the ``school_closure_policy``, ``days_closed``,
-``global_closure_trigger``, and ``local_closure_trigger`` variables into
-the ``parameters.fred`` file to test and plot various scenarios seen
-below. Note that unless stated otherwise, the variables in the
-simulation represented below are:
+FRED variables are modified in the :filename:`METHODS` script for this model,
+which overwrites various combinations the ``school_closure_policy``,
+``days_closed``, ``global_closure_trigger``, and ``local_closure_trigger`` variables.
+For each combination of interest, the changes are written into the
+``parameters.fred`` file and then ``fred_job`` is called to execute the model
+with the modified parameters. This produces a
+range of results as captured in the following figures.
+
+In each figure, the modified variable values are shown in the legend for
+the figure. The other variables not represented in a figure use the
+following default values:
 
 -  ``global_closure_trigger = 1000``
+
 -  ``local_closure_trigger = 20``
--  ``days_closed = 28``.
+
+-  ``days_closed = 28``
 
 Changing the ``global_closure_trigger`` Variable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/simpleflu/README.md
+++ b/simpleflu/README.md
@@ -95,10 +95,15 @@ The only remaining state in `INFLUENZA` is the `Import` state, which is the star
 
 ## Sample Model Outputs
 
-This model can be run using the **`METHODS`** file, which is a `bash` script that runs the model and uses `fred_plot` to generate a histogram of the number of new infections per day (and week, not shown).
+This model can be run using the FRED Local product. As discussed in
+the [FRED Local Guide](https://docs.epistemix.com/projects/fred-local/en/latest/chapter2.html#direct-shell-access), you can gain direct shell access to the
+FRED Local Container and then use the **`METHODS`** file to
+execute the model.  The **`METHODS`** file is a `bash` script that runs the
+model, using `fred_plot` to generate a histogram of the number of new infections per day (and week, which is not shown).
 
 ```bash
-$ ./METHODS
+$ docker exec -it fred /bin/bash
+root@a48b40b88a53:/fred/models# ./METHODS
 
 fred_job: starting job simpleflu at <date>
 
@@ -118,6 +123,8 @@ fred_job: finished job simpleflu <job key> at <date>
 
 fred_plot: image_file = daily.pdf
 fred_plot: image_file = weekly.pdf
+
+root@a48b40b88a53:/fred/models# 
 ```
 
 The results are consistent with the INFLUENZA condition propagating through the specified population, resulting in agents moving to the `Recovered` state. Eventually, a large fraction of the population is immune and the condition can no longer transmit.
@@ -129,11 +136,17 @@ The results are consistent with the INFLUENZA condition propagating through the 
 
 This tutorial introduces two concepts:
 
-- a **condition** with **states** that can be transmitted between agents.
-- a **meta agent** that introduces the condition to the population.
+1. a **condition** with **states** that can be transmitted between agents.
+
+2.  a **meta agent** that introduces the condition to the population.
 
 Within the states in `INFLUENZA`, we also used:
 
-- `wait()`, which causes the agent to pause in a given state
-- `next()`, which causes an agent to transition to a new state
-- two forms of probabilistic behavior, using `lognormal()` to generate wait times and the combination of `next() with prob()` and `default()` to probabilistically transition an agent to symptomatic or asymptomatic infectious states.
+* `wait()`, which causes the agent to pause in a given state
+
+* `next()`, which causes an agent to transition to a new state
+
+* two forms of probabilistic behavior, using `lognormal()` to generate wait
+  times and the combination of `next() with prob()` and `default()` to
+  probabilistically transition an agent to symptomatic or asymptomatic
+  infectious states.

--- a/vaccine/README.md
+++ b/vaccine/README.md
@@ -169,10 +169,12 @@ The `METHODS` file in this directory defines two different FRED jobs by sequenti
 
 ## Sample Model Outputs
 
-This model is run using the `METHODS` file.
+This model is run using the `METHODS` file in a
+[FRED Local](https://docs.epistemix.com/projects/fred-local) container.
 Running this file produces two sets of outputs that differ only in the proportion of the population that is originally vaccinated, 0% or 30%.
 Ideally, there would be a testing step in development to make sure that vaccines are being transmitted and imparting immunity (or reducing susceptibility) in the way that is expected.
-We can see that initially vaccinating 30% of the population reduces the cumulative infections substantially, providing evidence the `INFLUENZA_VACCINE` condition is functioning as expected.
+We can see that initially vaccinating 30% of the population reduces the cumulative infections substantially, providing evidence that
+the `INFLUENZA_VACCINE` condition is functioning as expected.
 
 ![Cumulative cases over time](figures/vaccine-tot.png)
 


### PR DESCRIPTION
This now links to and references FRED Local documentation for executing the models.
Since this is the only way we make FRED available to external users, it makes sense
to use this in our examples.
